### PR TITLE
Don't run init during validate command

### DIFF
--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -3,5 +3,4 @@ if [[ ! -d "$TF_PARAM_PATH" ]]; then
     echo "Path does not exist: \"$TF_PARAM_PATH\""
     exit 1
 fi
-terraform init -input=false -backend=false -no-color "$TF_PARAM_PATH"
 terraform validate -no-color "$TF_PARAM_PATH"


### PR DESCRIPTION
If users want to run init, they can do it explicitly themselves. Running
init unnecessarily slows down command execution.