### PR TITLE
Provide backend_config to init command

### DIFF
--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -61,6 +61,8 @@ steps:
             at: << parameters.workspace-root >>
   - init:
       path: << parameters.path >>
+      backend_config: << parameters.backend_config >>
+      backend_config_file: << parameters.backend_config_file >>
   - apply:
       path: << parameters.path >>
       var: << parameters.var >>


### PR DESCRIPTION
Fixes issue: #8 

Pass backend_config to the init command on init step.

**NOTE**: It is interesting that the apply job is already running an init. However, to make this change minimal without any unexpected consequences, I am providing the backend_config parameters to the init step.