### PR TITLE
Ensure no name conflicts occur during install

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -11,6 +11,7 @@ steps:
   - run:
       name: Install terraform binary
       command: |
+        cd $(mktemp -d -t tf-install-XXXXXXXXXX)
         wget https://releases.hashicorp.com/terraform/<< parameters.terraform_version >>/terraform_<< parameters.terraform_version >>_linux_amd64.zip
         unzip terraform_<< parameters.terraform_version >>_linux_amd64.zip
         sudo mv terraform /usr/local/bin


### PR DESCRIPTION
During install, if a folder or file named 'terraform' exists in the repository or working_dir root, the installation will fail. This ensures that the installation occurs in a directory of its own.