### PR TITLE
Change install to latest and support arm [semver:major]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,18 +1,23 @@
 description: |
-  Install specified version of terraform.
+  Install specified version of terraform. If unspecified, the latest version will be installed.
 
 parameters:
   terraform_version:
     type: "string"
     description: "Specify version of terraform to install."
-    default: "0.13.5"
+    default: "latest"
+  platform:
+    type: enum
+    description: |
+      Specify the target platform to install Terraform to. By default, linux_amd64 will be used.
+      Options: [linux_amd64, linux_arm]
+    enum: [linux_amd64, linux_arm]
+    default: "linux_amd64"
 
 steps:
   - run:
       name: Install terraform binary
-      command: |
-        if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
-        wget https://releases.hashicorp.com/terraform/<< parameters.terraform_version >>/terraform_<< parameters.terraform_version >>_linux_amd64.zip
-        unzip terraform_<< parameters.terraform_version >>_linux_amd64.zip
-        $SUDO mv terraform /usr/local/bin
-        terraform version
+      environment:
+        TF_PARAM_VERSION: <<parameters.terraform_version>>
+        TF_PARAM_PLATFORM: <<parameters.platform>>
+      command: <<include(scripts/install.sh)>>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,14 +1,17 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 if [[ $TF_PARAM_VERSION == "latest" ]]; then
+  echo "Fetching latest version number"
   TF_PARAM_VERSION=$(curl -Ls -w '%{url_effective}' "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo '[0-9]+.[0-9]+.[0-9]+')
-  echo "Latest version of jq is $TF_PARAM_VERSION"
+  echo "Latest version of Terraform is $TF_PARAM_VERSION"
 fi
 
 # Fetch binary
 TF_INSTALL_FILE="TF-${TF_PARAM_PLATFORM}.zip"
+echo "Downloading Terraform v$TF_PARAM_VERSION for ${TF_PARAM_PLATFORM}"
 curl --output "$TF_INSTALL_FILE" \
 --silent --show-error --location --fail --retry 3 \
 "https://releases.hashicorp.com/terraform/${TF_PARAM_VERSION}/terraform_${TF_PARAM_VERSION}_${TF_PARAM_PLATFORM}.zip"
+echo "Installing"
 unzip "$TF_INSTALL_FILE"
 $SUDO mv terraform /usr/local/bin
 terraform version

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,6 +1,6 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 if [[ $TF_PARAM_VERSION == "latest" ]]; then
-  TF_PARAM_VERSION="$(curl -Ls -w '%{url_effective}' "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)"
+  TF_PARAM_VERSION=$(curl -Ls -w '%{url_effective}' "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo '[0-9]+.[0-9]+.[0-9]+')
   echo "Latest version of jq is $TF_PARAM_VERSION"
 fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,0 +1,14 @@
+if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+if [[ $TF_PARAM_VERSION == "latest" ]]; then
+  TF_PARAM_VERSION = $(curl -Ls -w %{url_effective} "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)
+  echo "Latest version of jq is $TF_PARAM_VERSION"
+fi
+
+# Fetch binary
+TF_INSTALL_FILE = "TF-${TF_PARAM_PLATFORM}.zip"
+curl --output "$TF_INSTALL_FILE" \
+--silent --show-error --location --fail --retry 3 \
+"https://releases.hashicorp.com/terraform/${TF_PARAM_VERSION}/terraform_${TF_PARAM_VERSION}_${TF_PARAM_PLATFORM}.zip"
+unzip "$TF_INSTALL_FILE"
+$SUDO mv terraform /usr/local/bin
+terraform version

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,11 +1,11 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 if [[ $TF_PARAM_VERSION == "latest" ]]; then
-  TF_PARAM_VERSION = $(curl -Ls -w %{url_effective} "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)
+  TF_PARAM_VERSION=$(curl -Ls -w %{url_effective} "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)
   echo "Latest version of jq is $TF_PARAM_VERSION"
 fi
 
 # Fetch binary
-TF_INSTALL_FILE = "TF-${TF_PARAM_PLATFORM}.zip"
+TF_INSTALL_FILE="TF-${TF_PARAM_PLATFORM}.zip"
 curl --output "$TF_INSTALL_FILE" \
 --silent --show-error --location --fail --retry 3 \
 "https://releases.hashicorp.com/terraform/${TF_PARAM_VERSION}/terraform_${TF_PARAM_VERSION}_${TF_PARAM_PLATFORM}.zip"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,6 +1,6 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 if [[ $TF_PARAM_VERSION == "latest" ]]; then
-  TF_PARAM_VERSION=$(curl -Ls -w %{url_effective} "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)
+  TF_PARAM_VERSION="$(curl -Ls -w '%{url_effective}' "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo [0-9]+.[0-9]+.[0-9]+)"
   echo "Latest version of jq is $TF_PARAM_VERSION"
 fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,7 +1,7 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 if [[ $TF_PARAM_VERSION == "latest" ]]; then
   echo "Fetching latest version number"
-  TF_PARAM_VERSION=$(curl -Ls -w '%{url_effective}' "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo '[0-9]+.[0-9]+.[0-9]+')
+  TF_PARAM_VERSION=$(curl -Ls -w '%{url_effective}' --retry 3 --fail "https://releases.hashicorp.com/terraform/" | grep -m1 -Eo 'terraform_[0-9]+.[0-9]+.[0-9]+<' | grep -m1 -Eo '[0-9]+.[0-9]+.[0-9]+')
   echo "Latest version of Terraform is $TF_PARAM_VERSION"
 fi
 


### PR DESCRIPTION
Update the version parameter on the installation command to both accept "latest" as an option, and set the latest version to install by default.

- Solves #18
  - Rather than a new parameter, this uses the version parameter to accept the string "latest" and sets it as the default.