### PR TITLE
Rivera tf orb cmd updates to fix [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,18 +114,21 @@ workflows:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
             - terraform/validate
       - terraform/apply:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
             - terraform/plan
       - terraform/destroy:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
             - terraform/apply
       # Publish a semver version of the orb. relies on

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   terraform: circleci/terraform@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@10.0
   shellcheck: circleci/shellcheck@2.0
-
 # Pipeline Parameters
 ## These parameters are used internally by orb-tools. Skip to the Jobs section.
 parameters:
@@ -65,7 +64,6 @@ workflows:
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148
-
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
           orb-name: circleci/terraform
@@ -74,7 +72,6 @@ workflows:
             - orb-tools/lint
             - orb-tools/pack
             - shellcheck/check
-            
       # Trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
@@ -82,7 +79,6 @@ workflows:
           context: orb-publishing
           requires:
             - orb-tools/publish-dev
-
   # This `integration-test_deploy` workflow will only run
   # when the run-integration-tests pipeline parameter is set to true.
   # It is meant to be triggered by the "trigger-integration-tests-workflow"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   # Replace this with your own!
   terraform: circleci/terraform@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@10.0
-  bats: circleci/bats@1.0
   shellcheck: circleci/shellcheck@2.0
 
 # Pipeline Parameters
@@ -55,7 +54,6 @@ jobs:
       - terraform/install:
           terraform_version: "0.11.5"
 
-
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit
@@ -67,24 +65,16 @@ workflows:
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148
-      # optional: Run BATS tests against your scripts
-      # - bats/run:
-      #     path: ./src/tests
-      # If you accept building open source forks, protect your secrects behind a restricted context.
-      # A job containing restricted context (which holds your orb publishing credentials) may only be accessed by a user with proper permissions.
-      # An open source user may begin a pipeline with a PR, and once the pipeline is approved by an authorized user at this point, the pipeline will continue with the proper context permissions.
-      - hold-for-dev-publish:
-          type: approval
-          requires:
-            - orb-tools/lint
-            - orb-tools/pack
-            # - bats/run
-            - shellcheck/check
+
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
           orb-name: circleci/terraform
           context: orb-publishing # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
-          requires: [hold-for-dev-publish]
+          requires:
+            - orb-tools/lint
+            - orb-tools/pack
+            - shellcheck/check
+            
       # Trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
@@ -136,16 +126,12 @@ workflows:
           path: "src/infra"
           requires:
             - terraform/plan
-      - hold-destroy:
-          type: approval
-          requires:
-            - terraform/apply
       - terraform/destroy:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
           requires:
-            - hold-destroy
+            - terraform/apply
       # Publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,7 @@ orbs:
   # Replace this with your own!
   terraform: circleci/terraform@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@10.0
-  bats: circleci/bats@1.0
   shellcheck: circleci/shellcheck@2.0
-
 # Pipeline Parameters
 ## These parameters are used internally by orb-tools. Skip to the Jobs section.
 parameters:
@@ -55,7 +53,6 @@ jobs:
       - terraform/install:
           terraform_version: "0.11.5"
 
-
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit
@@ -67,24 +64,14 @@ workflows:
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148
-      # optional: Run BATS tests against your scripts
-      # - bats/run:
-      #     path: ./src/tests
-      # If you accept building open source forks, protect your secrects behind a restricted context.
-      # A job containing restricted context (which holds your orb publishing credentials) may only be accessed by a user with proper permissions.
-      # An open source user may begin a pipeline with a PR, and once the pipeline is approved by an authorized user at this point, the pipeline will continue with the proper context permissions.
-      - hold-for-dev-publish:
-          type: approval
-          requires:
-            - orb-tools/lint
-            - orb-tools/pack
-            # - bats/run
-            - shellcheck/check
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
           orb-name: circleci/terraform
           context: orb-publishing # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
-          requires: [hold-for-dev-publish]
+          requires:
+            - orb-tools/lint
+            - orb-tools/pack
+            - shellcheck/check
       # Trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
@@ -92,7 +79,6 @@ workflows:
           context: orb-publishing
           requires:
             - orb-tools/publish-dev
-
   # This `integration-test_deploy` workflow will only run
   # when the run-integration-tests pipeline parameter is set to true.
   # It is meant to be triggered by the "trigger-integration-tests-workflow"
@@ -128,24 +114,23 @@ workflows:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
             - terraform/validate
       - terraform/apply:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
             - terraform/plan
-      - hold-destroy:
-          type: approval
-          requires:
-            - terraform/apply
       - terraform/destroy:
           context: Terraform-orb-testing
           checkout: true
           path: "src/infra"
+          workspace: "orb-testing"
           requires:
-            - hold-destroy
+            - terraform/apply
       # Publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -17,7 +17,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |
@@ -96,12 +96,10 @@ steps:
         export PLAN_ARGS
         terraform init -input=false -no-color $INIT_ARGS "$module_path"
         # Test for saving state locally vs a remote state backend storage
-        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
-        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
-          # if workspace does not exist, create one
-          echo "[info] Using local state."
+        if [[ $workspace_parameter != "" ]]; then
+          echo "[INFO] Provisioning local workspace: $workspace"
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
-          echo "[info] Remote State Backend Enabled"
+          echo "[INFO] Remote State Backend Enabled"
         fi
         terraform apply -auto-approve $PLAN_ARGS "$module_path"

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -14,6 +14,10 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
+    default: true    
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -95,6 +99,10 @@ steps:
         fi
         export PLAN_ARGS
         terraform init -input=false -no-color $INIT_ARGS "$module_path"
-        # if workspace does not exist, create one
-        terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        # Test for saving state locally vs a remote state backend storage
+        export LOCAL_STATE=<< parameters.local_state >>
+        if [[ $LOCAL_STATE = true ]]; then
+          # if workspace does not exist, create one
+          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        fi
         terraform apply -auto-approve $PLAN_ARGS "$module_path"

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -100,9 +100,11 @@ steps:
         export PLAN_ARGS
         terraform init -input=false -no-color $INIT_ARGS "$module_path"
         # Test for saving state locally vs a remote state backend storage
-        export LOCAL_STATE=<< parameters.local_state >>
-        if [[ $LOCAL_STATE = true ]]; then
+        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
+        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
           # if workspace does not exist, create one
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        else
+          echo "Remote State Backend Enabled"
         fi
         terraform apply -auto-approve $PLAN_ARGS "$module_path"

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -17,7 +17,7 @@ parameters:
   local_state:
     type: "boolean"
     description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true    
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -14,10 +14,6 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -103,8 +99,9 @@ steps:
         export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
         if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
           # if workspace does not exist, create one
+          echo "[info] Using local state."
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
-          echo "Remote State Backend Enabled"
+          echo "[info] Remote State Backend Enabled"
         fi
         terraform apply -auto-approve $PLAN_ARGS "$module_path"

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -14,6 +14,10 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -98,8 +102,10 @@ steps:
         rm -rf .terraform
 
         terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"
-
-        terraform workspace select -no-color "$workspace" "$module_path"
+        if [[ $LOCAL_STATE = true ]]; then
+         terraform workspace select -no-color "$workspace" "$module_path"
+        fi
+ 
 
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -17,7 +17,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |
@@ -99,13 +99,11 @@ steps:
 
         terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"
         # Test for saving state locally vs a remote state backend storage
-        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
-        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
-          # if workspace does not exist, create one
-          echo "[info] Using local state."
-          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        if [[ $workspace_parameter != "" ]]; then
+          echo "[INFO] Provisioning local workspace: $workspace"
+          terraform workspace select -no-color "$workspace" "$module_path"
         else
-          echo "[info] Remote State Backend Enabled"
+          echo "[INFO] Remote State Backend Enabled"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -14,10 +14,6 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -106,9 +102,10 @@ steps:
         export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
         if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
           # if workspace does not exist, create one
-          terraform workspace select -no-color "$workspace" "$module_path"
+          echo "[info] Using local state."
+          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
-          echo "Remote State Backend Enabled"
+          echo "[info] Remote State Backend Enabled"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -105,8 +105,6 @@ steps:
         if [[ $LOCAL_STATE = true ]]; then
          terraform workspace select -no-color "$workspace" "$module_path"
         fi
- 
-
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do
                 PLAN_ARGS="$PLAN_ARGS -var $var"

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -102,8 +102,13 @@ steps:
         rm -rf .terraform
 
         terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"
-        if [[ $LOCAL_STATE = true ]]; then
-         terraform workspace select -no-color "$workspace" "$module_path"
+        # Test for saving state locally vs a remote state backend storage
+        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
+        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
+          # if workspace does not exist, create one
+          terraform workspace select -no-color "$workspace" "$module_path"
+        else
+          echo "Remote State Backend Enabled"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -16,7 +16,7 @@ parameters:
     default: ""
   local_state:
     type: "boolean"
-    description: "Save the Terraform state locally or remote backend"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
     default: true
   workspace:
     type: "string"
@@ -76,7 +76,7 @@ steps:
             done
         fi
         export INIT_ARGS
-        # Test for saving state locally vs a remote state storage
+        # Test for saving state locally vs a remote state backend storage
         export LOCAL_STATE=<< parameters.local_state >>
         if [[ $LOCAL_STATE = true ]]; then
           readonly workspace_parameter="<< parameters.workspace >>"

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -77,7 +77,7 @@ steps:
         fi
         export INIT_ARGS
         # Test for saving state locally vs a remote state storage
-        if [[ -n "<< parameters.local_state >> "]]; then
+        if [[ -n "<< parameters.local_state >>" ]]; then
           readonly workspace_parameter="<< parameters.workspace >>"
           readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
           export workspace

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -17,7 +17,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |
@@ -77,18 +77,17 @@ steps:
         readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
         export workspace
         unset TF_WORKSPACE
+
         terraform init -input=false -no-color $INIT_ARGS "$module_path"
+
         # Test for saving state locally vs a remote state backend storage
-        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
-        echo "[info] TF_SELECT_WORKSPACE = $TF_SELECT_WORKSPACE"
-        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
-          # if workspace does not exist, create one
-          echo "[info] Using local state."
+        if [[ $workspace_parameter != "" ]]; then
+          echo "[INFO] Provisioning local workspace: $workspace"
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
-          echo "[info] Remote State Backend Enabled"
-          terraform init -input=false -no-color $INIT_ARGS "$module_path"
-        fi
+          echo "[INFO] Remote State Backend Enabled"
+        if
+
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do
                 PLAN_ARGS="$PLAN_ARGS -var $var"

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -14,6 +14,10 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend"
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -72,13 +76,19 @@ steps:
                 INIT_ARGS="$INIT_ARGS -backend-config=$config"
             done
         fi
+
         export INIT_ARGS
-        readonly workspace_parameter="<< parameters.workspace >>"
-        readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
-        export workspace
-        unset TF_WORKSPACE
-        terraform init -input=false -no-color $INIT_ARGS "$module_path"
-        terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+
+        # Test for saving state locally vs a remote state storage
+        if [[ -n "<< paramters.local_state >> "]]; then
+          readonly workspace_parameter="<< parameters.workspace >>"
+          readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
+          export workspace
+          unset TF_WORKSPACE
+          terraform init -input=false -no-color $INIT_ARGS "$module_path"
+          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        fi
+        
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do
                 PLAN_ARGS="$PLAN_ARGS -var $var"

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -86,7 +86,7 @@ steps:
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
           echo "[INFO] Remote State Backend Enabled"
-        if
+        fi
 
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -14,10 +14,6 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -84,11 +80,13 @@ steps:
         terraform init -input=false -no-color $INIT_ARGS "$module_path"
         # Test for saving state locally vs a remote state backend storage
         export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
+        echo "[info] TF_SELECT_WORKSPACE = $TF_SELECT_WORKSPACE"
         if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
           # if workspace does not exist, create one
+          echo "[info] Using local state."
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
-          echo "Remote State Backend Enabled"
+          echo "[info] Remote State Backend Enabled"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -87,6 +87,7 @@ steps:
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         else
           echo "[info] Remote State Backend Enabled"
+          terraform init -input=false -no-color $INIT_ARGS "$module_path"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -77,7 +77,8 @@ steps:
         fi
         export INIT_ARGS
         # Test for saving state locally vs a remote state storage
-        if [[ -n "<< parameters.local_state >>" ]]; then
+        export LOCAL_STATE=<< parameters.local_state >>
+        if [[ $LOCAL_STATE = true ]]; then
           readonly workspace_parameter="<< parameters.workspace >>"
           readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
           export workspace

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -76,15 +76,19 @@ steps:
             done
         fi
         export INIT_ARGS
+
+        readonly workspace_parameter="<< parameters.workspace >>"
+        readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
+        export workspace
+        unset TF_WORKSPACE
+        terraform init -input=false -no-color $INIT_ARGS "$module_path"
         # Test for saving state locally vs a remote state backend storage
-        export LOCAL_STATE=<< parameters.local_state >>
-        if [[ $LOCAL_STATE = true ]]; then
-          readonly workspace_parameter="<< parameters.workspace >>"
-          readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
-          export workspace
-          unset TF_WORKSPACE
-          terraform init -input=false -no-color $INIT_ARGS "$module_path"
+        export TF_SELECT_WORKSPACE=$(terraform workspace select default 2>&1)
+        if [[ $TF_SELECT_WORKSPACE != *"workspaces not supported"* ]]; then
+          # if workspace does not exist, create one
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+        else
+          echo "Remote State Backend Enabled"
         fi
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -53,7 +53,6 @@ steps:
         # 'path' is a required parameter, save it as module_path
         readonly module_path="<< parameters.path >>"
         export path=$module_path
-
         if [[ ! -d "$module_path" ]]; then
           echo "Path does not exist: \"$module_path\""
           exit 1
@@ -76,11 +75,9 @@ steps:
                 INIT_ARGS="$INIT_ARGS -backend-config=$config"
             done
         fi
-
         export INIT_ARGS
-
         # Test for saving state locally vs a remote state storage
-        if [[ -n "<< paramters.local_state >> "]]; then
+        if [[ -n "<< parameters.local_state >> "]]; then
           readonly workspace_parameter="<< parameters.workspace >>"
           readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
           export workspace
@@ -88,7 +85,6 @@ steps:
           terraform init -input=false -no-color $INIT_ARGS "$module_path"
           terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
         fi
-        
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do
                 PLAN_ARGS="$PLAN_ARGS -var $var"

--- a/src/examples/deploy_using_remote_backend.yml
+++ b/src/examples/deploy_using_remote_backend.yml
@@ -1,0 +1,40 @@
+description: |
+  Deploy infrastructure that uses a remote backend to manage state. This example uses a Terraform Cloud example and references a remote.hcl file to specify the backend config.
+
+usage:
+  version: 2.1
+  orbs:
+    terraform: circleci/terraform@x.y.z
+  jobs:
+    single-job-lifecycle:
+      executor: terraform/default
+      working_directory: "~/src"
+      steps:
+        - checkout
+        - run:
+            name: "Create .terraformrc file locally"
+            command: echo "credentials \"app.terraform.io\" {token = \"$TERRAFORM_TOKEN\"}" > $HOME/.terraformrc
+        - terraform/install:
+            terraform_version: "0.14.2"
+            arch: "amd64"
+            os: "linux"
+        - terraform/fmt:
+            path: "."
+        - terraform/validate:
+            path: "."
+        - terraform/init:
+            path: "."
+            backend: true
+            backend_config_file: backend.hcl #See the Using CLI Input section for details on creating backend configuration file: https://www.terraform.io/docs/language/settings/backends/remote.html#using-cli-input
+        - terraform/plan:
+            path: "."
+            backend_config_file: backend.hcl
+        - terraform/apply:
+            path: "."
+            backend_config_file: backend.hcl
+        - terraform/destroy:
+            path: "."
+  workflows:
+    single-job-lifecycle:
+      jobs:
+        - single-job-lifecycle

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -37,7 +37,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -34,6 +34,10 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -72,6 +76,7 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
+      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -34,10 +34,6 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -76,7 +72,6 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
-      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -29,7 +29,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -26,6 +26,10 @@ parameters:
     type: "string"
     description: "Comma separated list of vars file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -62,6 +66,7 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
+      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -26,10 +26,6 @@ parameters:
     type: "string"
     description: "Comma separated list of vars file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -66,7 +62,6 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
-      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -37,7 +37,7 @@ parameters:
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
-    default: "default"
+    default: ""
   backend_config:
     type: "string"
     description: |

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -37,7 +37,7 @@ parameters:
   local_state:
     type: "boolean"
     description: "Save the Terraform state locally or remote backend"
-    default: true    
+    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -36,7 +36,7 @@ parameters:
     default: ""
   local_state:
     type: "boolean"
-    description: "Save the Terraform state locally or remote backend"
+    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
     default: true
   workspace:
     type: "string"
@@ -77,6 +77,7 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
+      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -34,6 +34,10 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
+  local_state:
+    type: "boolean"
+    description: "Save the Terraform state locally or remote backend"
+    default: true    
   workspace:
     type: "string"
     description: "Name of the terraform workspace"

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -34,10 +34,6 @@ parameters:
     type: "string"
     description: "Comma separated list of var file paths"
     default: ""
-  local_state:
-    type: "boolean"
-    description: "Save the Terraform state locally or remote backend. If a remote backend is defined in Terraform code this should be false."
-    default: true
   workspace:
     type: "string"
     description: "Name of the terraform workspace"
@@ -77,7 +73,6 @@ steps:
       path: << parameters.path >>
       var: << parameters.var >>
       var_file: << parameters.var_file >>
-      local_state: << parameters.local_state >>
       workspace: << parameters.workspace >>
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>


### PR DESCRIPTION
Updated the orb to handle state locally or by remote. The original orb schemes around local terraform workspaces were conflicting with the execution of TF code if a remote state backend such as Terraform cloud or AWS s3 are defined. I added a new parameter to act as a toggle flag that specifies if a user wants to use local or remote state backends.

@KyleTryon + @aedifex pls review and test my changes. I tested the orbs using live repos and the changes solved the issue I was experiencing. 