### PR TITLE
Use -chdir to set working directory

### DIFF
--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -94,7 +94,7 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform init -input=false -no-color $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
           echo "[INFO] Provisioning local workspace: $workspace"
@@ -102,4 +102,4 @@ steps:
         else
           echo "[INFO] Remote State Backend Enabled"
         fi
-        terraform apply -auto-approve $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" apply -auto-approve $PLAN_ARGS

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -97,7 +97,7 @@ steps:
 
         rm -rf .terraform
 
-        terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -lock-timeout=300s -no-color $INIT_ARGS
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
           echo "[INFO] Provisioning local workspace: $workspace"
@@ -128,4 +128,4 @@ steps:
 
         export PLAN_ARGS
 
-        terraform destroy -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" destroy -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_ARGS

--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -67,4 +67,4 @@ steps:
             done
         fi
         export INIT_ARGS
-        terraform init -input=false -no-color -backend=$backend $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -no-color -backend=$backend $INIT_ARGS

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -106,4 +106,4 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform plan -input=false -no-color -out=plan.out $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" plan -input=false -no-color -out=plan.out $PLAN_ARGS

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -3,5 +3,5 @@ if [[ ! -d "$TF_PARAM_PATH" ]]; then
     echo "Path does not exist: \"$TF_PARAM_PATH\""
     exit 1
 fi
-terraform init -input=false -backend=false -no-color "$TF_PARAM_PATH"
+terraform  -chdir="$TF_PARAM_PATH" init -input=false -backend=false -no-color
 terraform validate -no-color "$TF_PARAM_PATH"

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -3,5 +3,5 @@ if [[ ! -d "$TF_PARAM_PATH" ]]; then
     echo "Path does not exist: \"$TF_PARAM_PATH\""
     exit 1
 fi
-terraform  -chdir="$TF_PARAM_PATH" init -input=false -backend=false -no-color
-terraform validate -no-color "$TF_PARAM_PATH"
+terraform -chdir="$TF_PARAM_PATH" init -input=false -backend=false -no-color
+terraform -chdir="$TF_PARAM_PATH" validate -no-color


### PR DESCRIPTION
[Terraform 1.5.0](https://github.com/hashicorp/terraform/releases/tag/v0.15.0) removed the ability to specify a working directory for `terraform` commands via positional argument, replacing it with a named `-chdir` argument. The orb's executor pulls in the `hashicorp/terraform:light` image, which uses the latest version of terraform, and 1.5.0 was released today (4/14), breaking the orb for us.

This PR changes every `terraform` command that uses positional arguments to specify the working directory to add the `-chdir` argument before the subcommand name.

[Relevant docs](https://www.terraform.io/docs/cli/commands/#switching-working-directory-with-chdir)

**[PR is in draft while I figure out the proper testing procedure for Orbs!]**