### PR TITLE
[semver:patch] set default exec to tag

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,4 +8,4 @@ parameters:
   image:
     description: Specify Docker image for executor
     type: string
-    default: hashicorp/terraform:light
+    default: hashicorp/terraform:0.14.10


### PR DESCRIPTION
Set the default docker executor to a known good tag.