### PR TITLE
[semver:minor] Use same Terraform version in executor and install command

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,7 +5,7 @@ parameters:
   terraform_version:
     type: "string"
     description: "Specify version of terraform to install."
-    default: "0.13.5"
+    default: "0.14.11" # should match executor
   os:
     type: enum
     description: "Specify the operating system version to install. Must be one of these values: linux, darwin"

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,4 +8,4 @@ parameters:
   image:
     description: Specify Docker image for executor
     type: string
-    default: hashicorp/terraform:0.14.11
+    default: hashicorp/terraform:0.14.11 # update commands/install when updating this

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,4 +8,4 @@ parameters:
   image:
     description: Specify Docker image for executor
     type: string
-    default: hashicorp/terraform:0.14.10
+    default: hashicorp/terraform:0.14.11


### PR DESCRIPTION
I noticed that the executor had drifted from the `install` command. The command is still installing 0.13. I've updated to the latest 0.14, matched the two, and left comments on both lines to try to remind contributors to keep the versions in sync. 

I wanted to reference this value from a single place but couldn't come up with a way to do so. I thought to try `include()` but it has to be the only expression in the string and cannot be used for interpolation.