### PR TITLE
Apply plan file + -chdir option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       - terraform/apply:
           path: "src/infra"
           workspace: "orb-testing"
+          plan_file: plan.out
       - terraform/destroy:
           path: "src/infra"
           workspace: "orb-testing"
@@ -115,6 +116,7 @@ workflows:
           checkout: true
           path: "src/infra"
           workspace: "orb-testing"
+          persist-workspace: true
           requires:
             - terraform/validate
       - terraform/apply:
@@ -122,6 +124,8 @@ workflows:
           checkout: true
           path: "src/infra"
           workspace: "orb-testing"
+          attach-workspace: true
+          plan_file: plan.out
           requires:
             - terraform/plan
       - terraform/destroy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,11 @@ jobs:
       - terraform/plan:
           path: "src/infra"
           workspace: "orb-testing"
+          plan_file: plan.custom
       - terraform/apply:
           path: "src/infra"
           workspace: "orb-testing"
-          plan_file: plan.out
+          plan_file: plan.custom
       - terraform/destroy:
           path: "src/infra"
           workspace: "orb-testing"
@@ -117,6 +118,7 @@ workflows:
           path: "src/infra"
           workspace: "orb-testing"
           persist-workspace: true
+          plan_file: plan.out
           requires:
             - terraform/validate
       - terraform/apply:

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -56,10 +56,8 @@ steps:
         # the following is needed to process backend configs
         if [[ -n "<< parameters.backend_config_file >>" ]]; then
             for file in $(echo "<< parameters.backend_config_file >>" | tr ',' '\n'); do
-                if [[ -f "$file" ]]; then
+                if [[ -f "$module_path/$file" ]]; then
                     INIT_ARGS="$INIT_ARGS -backend-config=$file"
-                elif [[ -f "$module_path/$file" ]]; then
-                    INIT_ARGS="$INIT_ARGS -backend-config=$module_path/$file"
                 else
                     echo "Backend config '$file' wasn't found" >&2
                     exit 1
@@ -83,10 +81,8 @@ steps:
         fi
         if [[ -n "<< parameters.var_file >>" ]]; then
         for file in $(echo "<< parameters.var_file >>" | tr ',' '\n'); do
-            if [[ -f "$file" ]]; then
+            if [[ -f "$module_path/$file" ]]; then
                 PLAN_ARGS="$PLAN_ARGS -var-file=$file"
-            elif [[ -f "$module_path/$file" ]]; then
-                PLAN_ARGS="$PLAN_ARGS -var-file=$module_path/$file"
             else
                 echo "var file '$file' wasn't found" >&2
                 exit 1
@@ -94,12 +90,12 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform init -input=false -no-color $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
           echo "[INFO] Provisioning local workspace: $workspace"
-          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+          terraform -chdir="$module_path" workspace select -no-color "$workspace" || terraform -chdir="$module_path" workspace new -no-color "$workspace"
         else
           echo "[INFO] Remote State Backend Enabled"
         fi
-        terraform apply -auto-approve $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" apply -auto-approve $PLAN_ARGS

--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -31,6 +31,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan_file:
+    type: "string"
+    description: "Path to a saved plan file to execute"
+    default: ""
 
 steps:
   - run:
@@ -76,20 +80,20 @@ steps:
         unset TF_WORKSPACE
         if [[ -n "<< parameters.var >>" ]]; then
             for var in $(echo "<< parameters.var >>" | tr ',' '\n'); do
-                PLAN_ARGS="$PLAN_ARGS -var $var"
+                APPLY_ARGS="$APPLY_ARGS -var $var"
             done
         fi
         if [[ -n "<< parameters.var_file >>" ]]; then
         for file in $(echo "<< parameters.var_file >>" | tr ',' '\n'); do
             if [[ -f "$module_path/$file" ]]; then
-                PLAN_ARGS="$PLAN_ARGS -var-file=$file"
+                APPLY_ARGS="$APPLY_ARGS -var-file=$file"
             else
                 echo "var file '$file' wasn't found" >&2
                 exit 1
             fi
         done
         fi
-        export PLAN_ARGS
+        export APPLY_ARGS
         terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
@@ -98,4 +102,13 @@ steps:
         else
           echo "[INFO] Remote State Backend Enabled"
         fi
-        terraform -chdir="$module_path" apply -auto-approve $PLAN_ARGS
+        readonly plan_file="<< parameters.plan_file >>"
+        if [[ -n "$plan_file" ]]; then
+          if [[ -f "$module_path/$plan_file" ]]; then
+            export plan_file
+          else
+            echo "Saved plan path does not exist: \"$module_path\""
+            exit 1
+          fi
+        fi
+        terraform -chdir="$module_path" apply -auto-approve $APPLY_ARGS $plan_file

--- a/src/commands/destroy.yml
+++ b/src/commands/destroy.yml
@@ -61,10 +61,8 @@ steps:
 
         if [[ -n "<< parameters.backend_config_file >>" ]]; then
             for file in $(echo "<< parameters.backend_config_file >>" | tr ',' '\n'); do
-                if [[ -f "$file" ]]; then
+                if [[ -f "$module_path/$file" ]]; then
                     INIT_ARGS="$INIT_ARGS -backend-config=$file"
-                elif [[ -f "$module_path/$file" ]]; then
-                    INIT_ARGS="$INIT_ARGS -backend-config=$module_path/$file"
                 else
                     echo "Backend config '$file' wasn't found" >&2
                     exit 1
@@ -97,11 +95,11 @@ steps:
 
         rm -rf .terraform
 
-        terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -lock-timeout=300s -no-color $INIT_ARGS
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
           echo "[INFO] Provisioning local workspace: $workspace"
-          terraform workspace select -no-color "$workspace" "$module_path"
+          terraform -chdir="$module_path" workspace select -no-color "$workspace"
         else
           echo "[INFO] Remote State Backend Enabled"
         fi
@@ -117,7 +115,7 @@ steps:
                 if [[ -f "$file" ]]; then
                     PLAN_ARGS="$PLAN_ARGS -var-file=$file"
                 elif [[ -f "$module_path/$file" ]]; then
-                    PLAN_ARGS="$PLAN_ARGS -var-file=$module_path/$file"
+                    PLAN_ARGS="$PLAN_ARGS -var-file=$file"
                 else
                     echo "Var file '$file' wasn't found" >&2
                     exit 1
@@ -128,4 +126,4 @@ steps:
 
         export PLAN_ARGS
 
-        terraform destroy -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" destroy -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_ARGS

--- a/src/commands/fmt.yml
+++ b/src/commands/fmt.yml
@@ -23,4 +23,4 @@ steps:
           echo "Path does not exist: \"$module_path\""
           exit 1
         fi
-        terraform fmt -no-color -check -diff <<# parameters.recursive >> -recursive <</ parameters.recursive >> "$module_path"
+        terraform -chdir="$module_path" fmt -no-color -check -diff <<# parameters.recursive >> -recursive <</ parameters.recursive >>

--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -65,4 +65,4 @@ steps:
             done
         fi
         export INIT_ARGS
-        terraform -chdir="$module_path" init -input=false -no-color -backend=$backend $INIT_ARGS 
+        terraform -chdir="$module_path" init -input=false -no-color -backend=$backend $INIT_ARGS

--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -51,10 +51,8 @@ steps:
         # Initialize terraform
         if [[ -n "<< parameters.backend_config_file >>" ]]; then
             for file in $(echo "<< parameters.backend_config_file >>" | tr ',' '\n'); do
-                if [[ -f "$file" ]]; then
+                if [[ -f "$module_path/$file" ]]; then
                     INIT_ARGS="$INIT_ARGS -backend-config=$file"
-                elif [[ -f "$module_path/$file" ]]; then
-                    INIT_ARGS="$INIT_ARGS -backend-config=$module_path/$file"
                 else
                     echo "Backend config '$file' wasn't found" >&2
                     exit 1
@@ -67,4 +65,4 @@ steps:
             done
         fi
         export INIT_ARGS
-        terraform init -input=false -no-color -backend=$backend $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -no-color -backend=$backend $INIT_ARGS 

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -56,10 +56,8 @@ steps:
         # the following is needed to process backend configs
         if [[ -n "<< parameters.backend_config_file >>" ]]; then
             for file in $(echo "<< parameters.backend_config_file >>" | tr ',' '\n'); do
-                if [[ -f "$file" ]]; then
+                if [[ -f "$module_path/$file" ]]; then
                     INIT_ARGS="$INIT_ARGS -backend-config=$file"
-                elif [[ -f "$module_path/$file" ]]; then
-                    INIT_ARGS="$INIT_ARGS -backend-config=$module_path/$file"
                 else
                     echo "Backend config '$file' wasn't found" >&2
                     exit 1
@@ -78,12 +76,12 @@ steps:
         export workspace
         unset TF_WORKSPACE
 
-        terraform init -input=false -no-color $INIT_ARGS "$module_path"
+        terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS 
 
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then
           echo "[INFO] Provisioning local workspace: $workspace"
-          terraform workspace select -no-color "$workspace" "$module_path" || terraform workspace new -no-color "$workspace" "$module_path"
+          terraform -chdir="$module_path" workspace select -no-color "$workspace" || terraform -chdir="$module_path" workspace new -no-color "$workspace"
         else
           echo "[INFO] Remote State Backend Enabled"
         fi
@@ -95,10 +93,8 @@ steps:
         fi
         if [[ -n "<< parameters.var_file >>" ]]; then
         for file in $(echo "<< parameters.var_file >>" | tr ',' '\n'); do
-            if [[ -f "$file" ]]; then
+            if [[ -f "$module_path/$file" ]]; then
                 PLAN_ARGS="$PLAN_ARGS -var-file=$file"
-            elif [[ -f "$module_path/$file" ]]; then
-                PLAN_ARGS="$PLAN_ARGS -var-file=$module_path/$file"
             else
                 echo "var file '$file' wasn't found" >&2
                 exit 1
@@ -106,4 +102,4 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform plan -input=false -no-color -out=plan.out $PLAN_ARGS "$module_path"
+        terraform -chdir="$module_path" plan -input=false -no-color -out=plan.out $PLAN_ARGS

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -76,7 +76,7 @@ steps:
         export workspace
         unset TF_WORKSPACE
 
-        terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS 
+        terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
 
         # Test for saving state locally vs a remote state backend storage
         if [[ $workspace_parameter != "" ]]; then

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -31,6 +31,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan_file:
+    type: "string"
+    description: "Path to save the plan as a file"
+    default: "plan.out"
 
 
 steps:
@@ -102,4 +106,7 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform -chdir="$module_path" plan -input=false -no-color -out=plan.out $PLAN_ARGS
+        if [[ -n "<< parameters.plan_file >>" ]]; then
+          export plan_file="-out=<< parameters.plan_file >>"
+        fi
+        terraform -chdir="$module_path" plan -input=false -no-color $plan_file $PLAN_ARGS

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -107,6 +107,7 @@ steps:
         fi
         export PLAN_ARGS
         if [[ -n "<< parameters.plan_file >>" ]]; then
-          export plan_file="-out=<< parameters.plan_file >>"
+          PLAN_ARGS="$PLAN_ARGS -out=<< parameters.plan_file >>"
         fi
-        terraform -chdir="$module_path" plan -input=false -no-color $plan_file $PLAN_ARGS
+        export PLAN_ARGS
+        terraform -chdir="$module_path" plan -input=false -no-color $PLAN_ARGS

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -51,6 +51,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan_file:
+    type: "string"
+    description: "Path to a saved plan file to execute"
+    default: ""
 
 executor: default
 steps:
@@ -76,6 +80,7 @@ steps:
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>
       cli_config_file: << parameters.cli_config_file >>
+      plan_file: << parameters.plan_file >>
   - when:
       condition: << parameters.persist-workspace >>
       steps:

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -51,6 +51,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan_file:
+    type: "string"
+    description: "Path to save the plan as a file"
+    default: "plan.out"
 
 executor: default
 
@@ -77,6 +81,7 @@ steps:
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>
       cli_config_file: << parameters.cli_config_file >>
+      plan_file: << parameters.plan_file >>
   - when:
       condition: << parameters.persist-workspace >>
       steps:


### PR DESCRIPTION
closes #17 
related to #37 (for the chdir)
also related to #33 

Happy to contribute!
I initially needed for the orb to handle using the saved plan from plan command as input in the apply command. 
I saw that the parameter conflicted with the path parameter. 
Path is now handled in Terraform (since 0.14.x) with a -chdir option in commands and changes the cwd before running terraform commands so I removed module_path from all file options interpolation passed to the different commands.
I additionally took the liberty to treat #17 on the way.

This code is currently published in my forked orb so that I can already use these functionalities and running in my pipelines.

Let me know if this PR needs to be split for your review.
