### PR TITLE
Remove -out parameter

### DIFF
--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -106,4 +106,4 @@ steps:
         done
         fi
         export PLAN_ARGS
-        terraform plan -input=false -no-color -out=plan.out $PLAN_ARGS "$module_path"
+        terraform plan -input=false -no-color $PLAN_ARGS "$module_path"


### PR DESCRIPTION
This is not used anywhere as far as I can tell and prevents the orb being used with Terraform cloud

```
Error: Saving a generated plan is currently not supported

The "remote" backend does not support saving the generated execution plan
locally at this time.
```