### PR TITLE
Pass the cli_config_file parameter through to the validate command

### DIFF
--- a/src/commands/validate.yml
+++ b/src/commands/validate.yml
@@ -6,10 +6,15 @@ parameters:
     type: "string"
     description: "Path to the terraform module"
     default: "."
+  cli_config_file:
+    type: "string"
+    description: "Path to terraform cli config file"
+    default: ""
 
 steps:
   - run:
       name: terraform validate
       environment:
         TF_PARAM_PATH: << parameters.path >>
+        TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
       command: <<include(scripts/validate.sh)>>

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -62,3 +62,4 @@ steps:
       backend: << parameters.backend >>
   - validate:
       path: << parameters.path >>
+      cli_config_file: << parameters.cli_config_file >>

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+# Check CLI config file
+if [[ -n "${TF_PARAM_CLI_CONFIG_FILE}" ]]; then
+    if [[ -f "${TF_PARAM_CLI_CONFIG_FILE}" ]]; then
+        export TF_CLI_CONFIG_FILE=${TF_PARAM_CLI_CONFIG_FILE}
+    else
+        echo "Terraform cli config does not exist: ${TF_PARAM_CLI_CONFIG_FILE}"
+        exit 1
+    fi
+fi
 export path=$TF_PARAM_PATH
 if [[ ! -d "$TF_PARAM_PATH" ]]; then
     echo "Path does not exist: $TF_PARAM_PATH"


### PR DESCRIPTION
Hi

I have encountered an error using the `terraform/validate` job with a custom `cli_config_file` parameter.

The custom config file is used in the job by the `init` step, but not the `validate` step, which results in the following error performing `terraform init` in the `validate` step:

```
Initializing modules...

Error: Required token could not be found

Run the following command to generate a token for app.terraform.io:
    terraform login


Exited with code exit status 1
```

This PR applies the custom config file to the `validate` step.