### PR TITLE
Change shell script conditional check to avoid "sh: : unknown operand" output when variable is empty

### DIFF
--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -56,7 +56,7 @@ export PLAN_ARGS
 # shellcheck disable=SC2086
 terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
 # Test for saving state locally vs a remote state backend storage
-if [[ $workspace_parameter != "" ]]; then
+if [[ -n "$workspace_parameter" ]]; then
     echo "[INFO] Provisioning local workspace: $workspace"
     terraform -chdir="$module_path" workspace select -no-color "$workspace" || terraform -chdir="$module_path" workspace new -no-color "$workspace"
 else

--- a/src/scripts/destroy.sh
+++ b/src/scripts/destroy.sh
@@ -57,7 +57,7 @@ rm -rf .terraform
 # terraform -chdir="$module_path" init -input=false -lock-timeout=300s -no-color $INIT_ARGS
 
 # Test for saving state locally vs a remote state backend storage
-if [[ $workspace_parameter != "" ]]; then
+if [[ -n "$workspace_parameter" ]]; then
   echo "[INFO] Provisioning local workspace: $workspace"
   terraform -chdir="$module_path" workspace select -no-color "$workspace"
 else

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -42,7 +42,7 @@ unset TF_WORKSPACE
 terraform -chdir="$module_path" init -input=false -no-color $INIT_ARGS
 
 # Test for saving state locally vs a remote state backend storage
-if [[ $workspace_parameter != "" ]]; then
+if [[ -n "$workspace_parameter" ]]; then
   echo "[INFO] Provisioning local workspace: $workspace"
   terraform -chdir="$module_path" workspace select -no-color "$workspace" || terraform -chdir="$module_path" workspace new -no-color "$workspace"
 else


### PR DESCRIPTION
Hi

Various terraform operations have `sh: : unknown operand` in the output when the `workspace_parameter` variable is empty.

This PR fixes that issue.