### PR TITLE
feat: add resource_class parameter for docker executor

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -12,5 +12,13 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -13,4 +13,4 @@ parameters:
   resource_class:
     description: Specify the resource class for Docker Executor
     type: string
-    default: "medium" # select docker executor resource_class from https://circleci.com/docs/ja/2.0/configuration-reference/#docker-executor 
+    default: "small"

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,9 +3,14 @@ description: >
 
 docker:
   - image: hashicorp/terraform:<< parameters.tag >>
+resource_class: << parameters.resource_class >>
 
 parameters:
   tag:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "medium" # select docker executor resource_class from https://circleci.com/docs/ja/2.0/configuration-reference/#docker-executor 

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -57,8 +57,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -55,10 +55,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -47,10 +47,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -49,8 +49,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/fmt.yml
+++ b/src/jobs/fmt.yml
@@ -28,8 +28,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/fmt.yml
+++ b/src/jobs/fmt.yml
@@ -26,10 +26,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:

--- a/src/jobs/init.yml
+++ b/src/jobs/init.yml
@@ -28,8 +28,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/init.yml
+++ b/src/jobs/init.yml
@@ -26,10 +26,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -57,8 +57,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -55,10 +55,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -41,8 +41,16 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
-    default: "small"
+    type: enum
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    default: small
 
 executor:
   name: default

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -39,10 +39,15 @@ parameters:
     description: Specify the Terraform Docker image tag for the executor
     type: string
     default: "1.0.0" # update commands/install when updating this
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"
 
 executor:
   name: default
   tag: << parameters.tag >>
+  resource_class: << parameters.resource_class >>
 
 steps:
   - when:


### PR DESCRIPTION
Add `resource_class` parameters for docker executor.

According to the official documentation, if you do not specify a size, `resource_class` will be set automatically.

> For new projects created after September 1, 2021 that do not specify a resource class, CircleCI will try to find the right default value for your organization. To avoid using a default, explicitly specify a resource class size in your config for each job.
https://circleci.com/docs/2.0/configuration-reference/#resourceclass

I want to add an option so that I can select `resource_class` size.
