### PR TITLE
ci: Orb tools 11 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,159 +1,36 @@
 version: 2.1
-
+setup: true
 orbs:
-  # Replace this with your own!
-  terraform: circleci/terraform@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@10.0
-  shellcheck: circleci/shellcheck@2.0
-# Pipeline Parameters
-## These parameters are used internally by orb-tools. Skip to the Jobs section.
-parameters:
-  run-integration-tests:
-    description: An internal flag to prevent integration test from running before a development version has been created.
-    type: boolean
-    default: false
-  dev-orb-version:
-    description: >
-      The development version of the orb to test.
-      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
-      A "dev:alpha" version must exist for the initial pipeline run.
-    type: string
-    default: "dev:alpha"
+  orb-tools: circleci/orb-tools@11.1
+  shellcheck: circleci/shellcheck@3.1
 
-jobs:
-  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
-  validate-command-sequence:
-    executor: terraform/default
-    steps:
-      - checkout
-      - terraform/init:
-          path: "src/infra"
-      - terraform/fmt:
-          path: "src/infra"
-      - terraform/validate:
-          path: "src/infra"
-      - terraform/plan:
-          path: "src/infra"
-          workspace: "orb-testing"
-      - terraform/apply:
-          path: "src/infra"
-          workspace: "orb-testing"
-      - terraform/destroy:
-          path: "src/infra"
-          workspace: "orb-testing"
-  validate-terraform-install:
-    machine:
-      image: ubuntu-2004:202010-01
-    steps:
-      - terraform/install
-  validate-terraform-install-old:
-    machine:
-      image: ubuntu-2004:202010-01
-    steps:
-      - terraform/install:
-          terraform_version: "1.0.0"
+filters: &filters
+  tags:
+    only: /.*/
 
 workflows:
-  # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
-  # This workflow will run on every commit
-  test-pack:
-    unless: << pipeline.parameters.run-integration-tests >>
+  lint-pack:
     jobs:
-      - orb-tools/lint # Lint Yaml files
-      - orb-tools/pack # Pack orb source
+      - orb-tools/lint:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/review:
+          filters: *filters
       - shellcheck/check:
-          dir: ./src/scripts
-          exclude: SC2148
-      # Publish development version(s) of the orb.
-      - orb-tools/publish-dev:
+          exclude: SC2148,SC2038,SC2086,SC2002,SC2016
+          filters: *filters
+      - orb-tools/publish:
           orb-name: circleci/terraform
-          context: orb-publishing # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
+          vcs-type: << pipeline.project.type >>
           requires:
-            - orb-tools/lint
-            - orb-tools/pack
-            - shellcheck/check
-      # Trigger an integration workflow to test the
-      # dev:${CIRCLE_SHA1:0:7} version of your orb
-      - orb-tools/trigger-integration-tests-workflow:
-          name: trigger-integration-dev
-          context: orb-publishing
-          requires:
-            - orb-tools/publish-dev
-  # This `integration-test_deploy` workflow will only run
-  # when the run-integration-tests pipeline parameter is set to true.
-  # It is meant to be triggered by the "trigger-integration-tests-workflow"
-  # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-test_deploy:
-    when: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      # Run any integration tests defined within the `jobs` key.
-      - validate-command-sequence:
-          context: CPE_ORBS_AWS
-      - validate-terraform-install
-      - validate-terraform-install-old
-      - terraform/init:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          requires:
-            - validate-command-sequence
-            - validate-terraform-install
-      - terraform/fmt:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          requires:
-            - terraform/init
-      - terraform/validate:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          requires:
-            - terraform/fmt
-      - terraform/plan:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          workspace: "orb-testing"
-          requires:
-            - terraform/validate
-      - terraform/apply:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          workspace: "orb-testing"
-          requires:
-            - terraform/plan
-      - terraform/destroy:
-          context: CPE_ORBS_AWS
-          checkout: true
-          path: "src/infra"
-          workspace: "orb-testing"
-          requires:
-            - terraform/apply
-      # Publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major|skip]"
-      # as that will determine whether a patch, minor or major
-      # version will be published or if publishing should
-      # be skipped.
-      # e.g. [semver:patch] will cause a patch version to be published.
-      - orb-tools/dev-promote-prod-from-commit-subject:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+          # Use a context to hold your publishing token.
           context: orb-publisher
-          orb-name: circleci/terraform
-          ssh-fingerprints: 45:59:71:c6:c2:66:86:3f:7c:78:30:1b:ed:7d:f0:8d
-          add-pr-comment: true
-          fail-if-semver-not-indicated: true
-          publish-version-tag: false
-          bot-token-variable: GHI_TOKEN
-          bot-user: cpe-bot
-          requires:
-            - validate-command-sequence
-            - terraform/init
-            - terraform/fmt
-            - terraform/validate
-            - terraform/plan
-            - terraform/apply
-            - terraform/destroy
-          filters:
-            branches:
-              only: master
+          filters: *filters
+      # Triggers the next workflow in the Orb Development Kit.
+      - orb-tools/continue:
+          pipeline-number: << pipeline.number >>
+          vcs-type: << pipeline.project.type >>
+          requires: [orb-tools/publish]
+          filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -6,18 +6,6 @@ orbs:
 filters: &filters
   tags:
     only: /.*/
-parameters:
-  run-integration-tests:
-    description: An internal flag to prevent integration test from running before a development version has been created.
-    type: boolean
-    default: false
-  dev-orb-version:
-    description: >
-      The development version of the orb to test.
-      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
-      A "dev:alpha" version must exist for the initial pipeline run.
-    type: string
-    default: "dev:alpha"
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   validate-command-sequence:
@@ -54,7 +42,7 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-       # Run any integration tests defined within the `jobs` key.
+      # Run any integration tests defined within the `jobs` key.
       - validate-command-sequence:
           context: CPE_ORBS_AWS
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,0 +1,130 @@
+version: 2.1
+orbs:
+  terraform: circleci/terraform@dev:<<pipeline.git.revision>>
+  orb-tools: circleci/orb-tools@11.1
+  shellcheck: circleci/shellcheck@2.0
+filters: &filters
+  tags:
+    only: /.*/
+parameters:
+  run-integration-tests:
+    description: An internal flag to prevent integration test from running before a development version has been created.
+    type: boolean
+    default: false
+  dev-orb-version:
+    description: >
+      The development version of the orb to test.
+      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
+      A "dev:alpha" version must exist for the initial pipeline run.
+    type: string
+    default: "dev:alpha"
+jobs:
+  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  validate-command-sequence:
+    executor: terraform/default
+    steps:
+      - checkout
+      - terraform/init:
+          path: "src/infra"
+      - terraform/fmt:
+          path: "src/infra"
+      - terraform/validate:
+          path: "src/infra"
+      - terraform/plan:
+          path: "src/infra"
+          workspace: "orb-testing"
+      - terraform/apply:
+          path: "src/infra"
+          workspace: "orb-testing"
+      - terraform/destroy:
+          path: "src/infra"
+          workspace: "orb-testing"
+  validate-terraform-install:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - terraform/install
+  validate-terraform-install-old:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - terraform/install:
+          terraform_version: "1.0.0"
+workflows:
+  test-deploy:
+    jobs:
+      # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+       # Run any integration tests defined within the `jobs` key.
+      - validate-command-sequence:
+          context: CPE_ORBS_AWS
+          filters: *filters
+      - validate-terraform-install:
+          filters: *filters
+      - validate-terraform-install-old:
+          filters: *filters
+      - terraform/init:
+          context: CPE_ORBS_AWS
+          filters: *filters
+          checkout: true
+          path: "src/infra"
+          requires:
+            - validate-command-sequence
+            - validate-terraform-install
+      - terraform/fmt:
+          context: CPE_ORBS_AWS
+          filters: *filters
+          checkout: true
+          path: "src/infra"
+          requires:
+            - terraform/init
+      - terraform/validate:
+          context: CPE_ORBS_AWS
+          checkout: true
+          path: "src/infra"
+          requires:
+            - terraform/fmt
+      - terraform/plan:
+          context: CPE_ORBS_AWS
+          filters: *filters
+          checkout: true
+          path: "src/infra"
+          workspace: "orb-testing"
+          requires:
+            - terraform/validate
+      - terraform/apply:
+          context: CPE_ORBS_AWS
+          filters: *filters
+          checkout: true
+          path: "src/infra"
+          workspace: "orb-testing"
+          requires:
+            - terraform/plan
+      - terraform/destroy:
+          context: CPE_ORBS_AWS
+          filters: *filters
+          checkout: true
+          path: "src/infra"
+          workspace: "orb-testing"
+          requires:
+            - terraform/apply
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/terraform
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - validate-command-sequence
+            - terraform/init
+            - terraform/fmt
+            - terraform/validate
+            - terraform/plan
+            - terraform/apply
+            - terraform/destroy
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: relaxed
+
+rules:
+    line-length:
+        max: 200
+        allow-non-breakable-inline-mappings: true

--- a/src/commands/fmt.yml
+++ b/src/commands/fmt.yml
@@ -14,13 +14,7 @@ parameters:
 steps:
   - run:
       name: terraform fmt
-      command: |
-        # 'path' is a required parameter, save it as module_path
-        readonly module_path="<< parameters.path >>"
-        export path=$module_path
-
-        if [[ ! -d "$module_path" ]]; then
-          echo "Path does not exist: \"$module_path\""
-          exit 1
-        fi
-        terraform -chdir="$module_path" fmt -no-color -check -diff <<# parameters.recursive >> -recursive <</ parameters.recursive >>
+      environment:
+        TF_PARAM_MOD_PATH: << parameters.path >>
+        TF_PARAM_IS_RECURSIVE: << parameters.recursive >>
+      command: <<include(scripts/fmt.sh)>>

--- a/src/scripts/fmt.sh
+++ b/src/scripts/fmt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# 'path' is a required parameter, save it as module_path
+readonly module_path="$TF_PARAM_MOD_PATH"
+export path=$module_path
+
+if [[ ! -d "$module_path" ]]; then
+  echo "Path does not exist: \"$module_path\""
+  exit 1
+fi
+if [ "$TF_PARAM_IS_RECURSIVE" = "1" ]; then
+ set -- "$@" -recursive
+fi
+terraform -chdir="$module_path" fmt -no-color -check -diff "$@"


### PR DESCRIPTION
This change makes it easier to address the next updates and standardizes the release process.

This change also includes refactoring the `fmt` command to use a script.