### PR TITLE
Support "latest" Terraform version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,8 +4,12 @@ description: |
 parameters:
   terraform_version:
     type: "string"
-    description: "Specify version of terraform to install."
-    default: "1.0.0" # should match executor
+    description: |
+      Version of Terraform to install. Only stable versions are supported. You can specify the version in three ways:
+      * latest: most recent version
+      * full version number (1.2.3): a specific version
+      * anything else (1.2, 1): the most recent stable version which matches this prefix.
+    default: latest
   os:
     type: enum
     description: "Specify the operating system version to install. Must be one of these values: linux, darwin"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,7 +9,7 @@ parameters:
       * latest: most recent version
       * full version number (1.2.3): a specific version
       * anything else (1.2, 1): the most recent stable version which matches this prefix.
-    default: latest
+    default: "1.0.0"
   os:
     type: enum
     description: "Specify the operating system version to install. Must be one of these values: linux, darwin"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,35 +1,54 @@
 #!/bin/bash
-mkdir -p /tmp/terraform-install
-cd /tmp/terraform-install || return
-wget -P /tmp "https://releases.hashicorp.com/terraform/${TF_PARAM_VERSION}/terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip"
-wget -nv "https://releases.hashicorp.com/terraform/${TF_PARAM_VERSION}/terraform_${TF_PARAM_VERSION}_SHA256SUMS"
 
+set -euo pipefail
+
+download_version() {
+	version=$1
+	local base_url="https://releases.hashicorp.com/terraform/${version}/terraform_${version}"
+	wget -nv "${base_url}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip"
+	wget -nv "${base_url}_SHA256SUMS"
+}
+
+init() {
+	mkdir -p /tmp/terraform-install
+	cd /tmp/terraform-install
+}
 
 # Reported in #61 that recent versions of the Terraform Docker image do not contain shasum
 # This is a backwards compatible fix for verifying the Terraform binary
 checksumCommand() {
+	file=$1
 	if [ "$(command -v shasum)" ]; then
-		shasum -a 256 "$1" | cut -d' ' -f1
+		shasum -a 256 "$file" | cut -d' ' -f1
 	elif [ "$(command -v sha256sum)" ]; then
-		sha256sum "$1" | cut -d' ' -f1
+		sha256sum "$file" | cut -d' ' -f1
 	else
 		echo "No checksum tools found."
 		exit 1
 	fi
 }
 
-# Validate checksum
-# shellcheck disable=SC2002
-expected_sha=$(cat "terraform_${TF_PARAM_VERSION}_SHA256SUMS" | grep "terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip" | awk '{print $1}')
-export -f checksumCommand
-download_sha=$(checksumCommand "/tmp/terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip")
-echo "Validating download..."
-if [ "$expected_sha" != "$download_sha" ]; then
-	echo "Expected SHA256SUM does not match downloaded file, exiting."
-	exit 1
-fi
+checksum_package() {
+	# Validate checksum
+	# shellcheck disable=SC2002
+	expected_sha=$(cat "terraform_${TF_PARAM_VERSION}_SHA256SUMS" | grep "terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip" | awk '{print $1}')
+	export -f checksumCommand
+	download_sha=$(checksumCommand "terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip")
+	echo "Validating download..."
+	if [ "$expected_sha" != "$download_sha" ]; then
+		echo "Expected SHA256SUM does not match downloaded file, exiting."
+		exit 1
+	fi
+}
 
-if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
-unzip -o "/tmp/terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip" -d /tmp
-$SUDO mv /tmp/terraform /usr/local/bin
+install_terraform() {
+	unzip -o "terraform_${TF_PARAM_VERSION}_${TF_PARAM_OS}_${TF_PARAM_ARCH}.zip"
+	if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+	$SUDO mv terraform /usr/local/bin
+}
+
+init
+download_version "${TF_PARAM_VERSION}"
+checksum_package
+install_terraform
 terraform version

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -euo pipefail
-
 download_version() {
 	version=$1
 	local base_url="https://releases.hashicorp.com/terraform/${version}/terraform_${version}"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -9,7 +9,7 @@ download_version() {
 
 init() {
 	mkdir -p /tmp/terraform-install
-	cd /tmp/terraform-install
+	cd /tmp/terraform-install || exit 1
 }
 
 # Reported in #61 that recent versions of the Terraform Docker image do not contain shasum


### PR DESCRIPTION
And version specifiers like `1` and `1.2` (picking the most recent matching stable version).