### PR TITLE
feat: optionally apply plan file

### DIFF
--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -31,6 +31,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan:
+    type: string
+    description: Optionally provide a plan file to supply to the 'apply' command.
+    default: ""
   timeout:
     description: Configure a custom timeout limit
     type: string
@@ -48,4 +52,5 @@ steps:
         TF_PARAM_BACKEND_CONFIG: <<parameters.backend_config>>
         TF_PARAM_BACKEND_CONFIG_FILE: <<parameters.backend_config_file>>
         TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
+        TF_PARAM_PLAN: <<parameters.plan>>
       command: <<include(scripts/apply.sh)>>

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -31,6 +31,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  out:
+    type: string
+    description: The file path to save your terraform plan to.
+    default: "plan.out"
   timeout:
     description: Configure a custom timeout limit
     type: string
@@ -48,4 +52,5 @@ steps:
         TF_PARAM_BACKEND_CONFIG: <<parameters.backend_config>>
         TF_PARAM_BACKEND_CONFIG_FILE: <<parameters.backend_config_file>>
         TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
+        TF_PARAM_OUT: << parameters.out >>
       command: <<include(scripts/plan.sh)>>

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -51,6 +51,10 @@ parameters:
     type: "string"
     description: "Path to terraform cli config file"
     default: ""
+  plan:
+    type: string
+    description: Optionally provide a plan file to supply to the 'apply' command.
+    default: ""
   tag:
     description: "Specify the Terraform Docker image tag for the executor"
     type: "string"
@@ -92,6 +96,7 @@ steps:
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>
       cli_config_file: << parameters.cli_config_file >>
+      plan: <<parameters.plan>>
       timeout: <<parameters.timeout>>
   - when:
       condition: << parameters.persist-workspace >>

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -55,6 +55,10 @@ parameters:
     description: "Specify the Terraform Docker image tag for the executor"
     type: "string"
     default: "1.0.0" # update commands/install when updating this
+  out:
+    type: string
+    description: The file path to save your terraform plan to.
+    default: "plan.out"
   timeout:
     description: "Configure a custom timeout limit"
     type: "string"
@@ -93,6 +97,7 @@ steps:
       backend_config: << parameters.backend_config >>
       backend_config_file: << parameters.backend_config_file >>
       cli_config_file: << parameters.cli_config_file >>
+      out: << parameters.out >>
       timeout: <<parameters.timeout>>
   - when:
       condition: << parameters.persist-workspace >>

--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -63,4 +63,4 @@ else
     echo "[INFO] Remote State Backend Enabled"
 fi
 # shellcheck disable=SC2086
-terraform -chdir="$module_path" apply -auto-approve $PLAN_ARGS
+terraform -chdir="$module_path" apply -auto-approve $PLAN_ARGS ${TF_PARAM_PLAN}

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -66,4 +66,4 @@ if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
 fi
 export PLAN_ARGS
 # shellcheck disable=SC2086
-terraform -chdir="$module_path" plan -input=false -out=plan.out $PLAN_ARGS
+terraform -chdir="$module_path" plan -input=false -out=${TF_PARAM_OUT} $PLAN_ARGS


### PR DESCRIPTION
# Fixes
- #63 

To use, the user must:
 1. Enable `attach-workspace` on the `plan` and `apply` jobs.
 2. The `plan` parameter must be set on the apply job
     - The `plan` job now parameterizes the name and path of the plan but defaults to `plan.out` as before.
     - By leaving the `plan` parameter on the `apply` job blank, there are no breaking changes.