### PR TITLE
fix: interpolate workspace variable to allow env

### DIFF
--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -33,7 +33,6 @@ if [[ -n "${TF_PARAM_BACKEND_CONFIG}" ]]; then
     done
 fi
 export INIT_ARGS
-readonly workspace_parameter
 workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
 export workspace

--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -33,7 +33,8 @@ if [[ -n "${TF_PARAM_BACKEND_CONFIG}" ]]; then
     done
 fi
 export INIT_ARGS
-readonly workspace_parameter="${TF_PARAM_WORKSPACE}"
+readonly workspace_parameter
+workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
 export workspace
 unset TF_WORKSPACE

--- a/src/scripts/destroy.sh
+++ b/src/scripts/destroy.sh
@@ -43,7 +43,6 @@ terraform -chdir="$module_path" init -input=false $INIT_ARGS
 
 # If TF_WORKSPACE is set we don't want terraform init to use the value, in the case we are running new_workspace.sh this would cause an error
 
-readonly workspace_parameter
 workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"

--- a/src/scripts/destroy.sh
+++ b/src/scripts/destroy.sh
@@ -43,7 +43,8 @@ terraform -chdir="$module_path" init -input=false $INIT_ARGS
 
 # If TF_WORKSPACE is set we don't want terraform init to use the value, in the case we are running new_workspace.sh this would cause an error
 
-readonly workspace_parameter="${TF_PARAM_WORKSPACE}"
+readonly workspace_parameter
+workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
 

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -33,7 +33,7 @@ if [[ -n "${TF_PARAM_BACKEND_CONFIG}" ]]; then
 fi
 export INIT_ARGS
 
-readonly workspace_parameter
+
 workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
 export workspace

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -33,7 +33,8 @@ if [[ -n "${TF_PARAM_BACKEND_CONFIG}" ]]; then
 fi
 export INIT_ARGS
 
-readonly workspace_parameter="${TF_PARAM_WORKSPACE}"
+readonly workspace_parameter
+workspace_parameter="$(eval echo "${TF_PARAM_WORKSPACE}")"
 readonly workspace="${TF_WORKSPACE:-$workspace_parameter}"
 export workspace
 unset TF_WORKSPACE


### PR DESCRIPTION
# Fixes:
 - Further addresses #51 in areas not satisfied by #72 as requested by @ksmnv
   - Allows for environment variables to be used in the terraform workspace parameter (`workspace`)