### PR TITLE
feat(plan,apply): add argument for lock timeout

### DIFF
--- a/src/commands/apply.yml
+++ b/src/commands/apply.yml
@@ -39,6 +39,10 @@ parameters:
     description: Configure a custom timeout limit
     type: string
     default: 10m
+  lock-timeout:
+    description: Configure a custom state lock timeout
+    type: string
+    default: 30s
 
 steps:
   - run:
@@ -53,4 +57,5 @@ steps:
         TF_PARAM_BACKEND_CONFIG_FILE: <<parameters.backend_config_file>>
         TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
         TF_PARAM_PLAN: <<parameters.plan>>
+        TF_PARAM_LOCK_TIMEOUT: << parameters.lock-timeout >>
       command: <<include(scripts/apply.sh)>>

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -39,6 +39,10 @@ parameters:
     description: Configure a custom timeout limit
     type: string
     default: 10m
+  lock-timeout:
+    description: Configure a custom state lock timeout
+    type: string
+    default: 30s
 
 steps:
   - run:
@@ -53,4 +57,5 @@ steps:
         TF_PARAM_BACKEND_CONFIG_FILE: <<parameters.backend_config_file>>
         TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
         TF_PARAM_OUT: << parameters.out >>
+        TF_PARAM_LOCK_TIMEOUT: << parameters.lock-timeout >>
       command: <<include(scripts/plan.sh)>>

--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -63,6 +63,10 @@ parameters:
     description: "Configure a custom timeout limit"
     type: "string"
     default: "10m"
+  lock-timeout:
+    description: Configure a custom state lock timeout
+    type: string
+    default: 30s
   resource_class:
     description: "Specify the resource class for Docker Executor"
     type: "string"
@@ -98,6 +102,7 @@ steps:
       cli_config_file: << parameters.cli_config_file >>
       plan: <<parameters.plan>>
       timeout: <<parameters.timeout>>
+      lock-timeout: <<parameters.lock-timeout>>
   - when:
       condition: << parameters.persist-workspace >>
       steps:

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -63,6 +63,10 @@ parameters:
     description: "Configure a custom timeout limit"
     type: "string"
     default: "10m"
+  lock-timeout:
+    description: Configure a custom state lock timeout
+    type: string
+    default: 30s
   resource_class:
     description: "Specify the resource class for Docker Executor"
     type: "string"
@@ -99,6 +103,7 @@ steps:
       cli_config_file: << parameters.cli_config_file >>
       out: << parameters.out >>
       timeout: <<parameters.timeout>>
+      lock-timeout: <<parameters.lock-timeout>>
   - when:
       condition: << parameters.persist-workspace >>
       steps:

--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -52,6 +52,10 @@ if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
         fi
     done
 fi
+
+if [[ -n "${TF_PARAM_LOCK_TIMEOUT}" ]]; then
+    PLAN_ARGS="$PLAN_ARGS -lock-timeout=${TF_PARAM_LOCK_TIMEOUT}"
+fi
 export PLAN_ARGS
 # shellcheck disable=SC2086
 terraform -chdir="$module_path" init -input=false $INIT_ARGS

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -64,6 +64,10 @@ if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
         fi
     done
 fi
+
+if [[ -n "${TF_PARAM_LOCK_TIMEOUT}" ]]; then
+    PLAN_ARGS="$PLAN_ARGS -lock-timeout=${TF_PARAM_LOCK_TIMEOUT}"
+fi
 export PLAN_ARGS
 # shellcheck disable=SC2086
 terraform -chdir="$module_path" plan -input=false -out=${TF_PARAM_OUT} $PLAN_ARGS


### PR DESCRIPTION
Addresses #82

This allows specifying a lock timeout value when running `plan` or `apply`. It is useful when running different builds in parallel that run the same terraform plan (It frequently happens if you have Dependabot enabled), they will fail unless you set a lock timeout.