### PR TITLE
feat(plan): Adding detailed-exitcode option for plan

### DIFF
--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -43,6 +43,10 @@ parameters:
     description: Configure a custom state lock timeout
     type: string
     default: 30s
+  detailed-exitcode:
+    description: Return detailed exit code
+    type: bool
+    default: false
 
 steps:
   - run:
@@ -58,4 +62,5 @@ steps:
         TF_PARAM_CLI_CONFIG_FILE: <<parameters.cli_config_file>>
         TF_PARAM_OUT: << parameters.out >>
         TF_PARAM_LOCK_TIMEOUT: << parameters.lock-timeout >>
+        TF_PARAM_DETAILED_EXITCODE: << parameters.detailed-exitcode >>
       command: <<include(scripts/plan.sh)>>

--- a/src/examples/deploy_infrastructure.yml
+++ b/src/examples/deploy_infrastructure.yml
@@ -1,7 +1,7 @@
 description: |
   Deploy infrastructure leveraging a sequence of jobs and workspaces to create and persist a terraform plan.
 
-  Apply will 'apply' the result of a terraform plan.
+  Apply will 'apply' the result of a terraform plan, if there is something in the plan.
 
 usage:
   version: 2.1
@@ -21,10 +21,12 @@ usage:
         - terraform/plan:
             checkout: true
             persist-workspace: true
+            detailed-exitcode: true
             context: terraform
             requires:
               - terraform/validate
         - terraform/apply:
+            when: on_fail
             attach-workspace: true
             context: terraform
             requires:

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -67,6 +67,10 @@ parameters:
     description: Configure a custom state lock timeout
     type: string
     default: 30s
+  detailed-exitcode:
+    description: Return detailed exit code
+    type: bool
+    default: false
   resource_class:
     description: "Specify the resource class for Docker Executor"
     type: "string"
@@ -104,6 +108,7 @@ steps:
       out: << parameters.out >>
       timeout: <<parameters.timeout>>
       lock-timeout: <<parameters.lock-timeout>>
+      detailed-exitcode: <<parameters.detailed-exitcode>>
   - when:
       condition: << parameters.persist-workspace >>
       steps:

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -68,6 +68,11 @@ fi
 if [[ -n "${TF_PARAM_LOCK_TIMEOUT}" ]]; then
     PLAN_ARGS="$PLAN_ARGS -lock-timeout=${TF_PARAM_LOCK_TIMEOUT}"
 fi
+
+if [[ -n "${TF_PARAM_DETAILED_EXITCODE}" ]]; then
+    PLAN_ARGS="$PLAN_ARGS -detailed-exitcode=${TF_PARAM_DETAILED_EXITCODE}"
+fi
+
 export PLAN_ARGS
 # shellcheck disable=SC2086
 terraform -chdir="$module_path" plan -input=false -out=${TF_PARAM_OUT} $PLAN_ARGS


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, Related Issues

We want to add an `approve` step when doing terraform through CircleCI. But, no approve is necessary if there is nothing to change. Instead of parsing the plan's output, we want to rely on the status code of the plan to decide if next steps are required.

### Description

`terraform plan` has an extra `-detailed-exitcode` that we pass as a configuration.