### PR TITLE
Add option to upgrade modules and providers

### DIFF
--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -27,6 +27,10 @@ parameters:
     description: Configure a custom timeout limit
     type: string
     default: 10m
+  upgrade:
+    description: "Install the latest terraform module and provider versions"
+    type: boolean
+    default: false
 
 steps:
   - run:
@@ -38,4 +42,5 @@ steps:
         TF_PARAM_BACKEND_CONFIG: << parameters.backend_config >>
         TF_PARAM_BACKEND_CONFIG_FILE: << parameters.backend_config_file >>
         TF_PARAM_CLI_CONFIG_FILE: << parameters.cli_config_file >>
+        TF_PARAM_UPGRADE: << parameters.upgrade >>
       command: <<include(scripts/init.sh)>>

--- a/src/scripts/init.sh
+++ b/src/scripts/init.sh
@@ -35,6 +35,11 @@ if [[ -n "${TF_PARAM_BACKEND_CONFIG}" ]]; then
         INIT_ARGS="$INIT_ARGS -backend-config=$(eval echo "$config")"
     done
 fi
+
+if [[ "${TF_PARAM_UPGRADE}" = true ]]; then
+    INIT_ARGS="$INIT_ARGS -upgrade"
+fi
+
 export INIT_ARGS
 # shellcheck disable=SC2086
 terraform -chdir="$module_path" init -input=false -backend=$backend $INIT_ARGS


### PR DESCRIPTION
This would add a boolean option for `init` command to allow upgrading Terraform module and provider versions to allowed within configured constraints, overriding the default behavior of selecting exactly the version recorded in the dependency lockfile.

Related to https://github.com/CircleCI-Public/terraform-orb/pull/91