### PR TITLE
Feat: update default executor version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 setup: true
 orbs:
   orb-tools: circleci/orb-tools@11.1
-  shellcheck: circleci/shellcheck@3.1
+  shellcheck: circleci/shellcheck@3.2
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   terraform: circleci/terraform@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@11.1
-  shellcheck: circleci/shellcheck@2.0
 filters: &filters
   tags:
     only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,12 +28,12 @@ jobs:
           workspace: "orb-testing"
   validate-terraform-install:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:2024.05.1
     steps:
       - terraform/install
   validate-terraform-install-old:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:2024.05.1
     steps:
       - terraform/install:
           terraform_version: "1.0.0"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,7 +9,8 @@ parameters:
       * latest: most recent version
       * full version number (1.2.3): a specific version
       * anything else (1.2, 1): the most recent stable version which matches this prefix.
-    default: "1.0.0"
+      Defaults to latest.
+    default: "latest"
   os:
     type: enum
     description: "Specify the operating system version to install. Must be one of these values: linux, darwin"

--- a/src/examples/deploy_infrastructure.yml
+++ b/src/examples/deploy_infrastructure.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    terraform: circleci/terraform@3.1
+    terraform: circleci/terraform@3.3
   workflows:
     deploy_infrastructure:
       jobs:

--- a/src/examples/deploy_infrastructure_job.yml
+++ b/src/examples/deploy_infrastructure_job.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    terraform: circleci/terraform@3.1
+    terraform: circleci/terraform@3.3
   jobs:
     single-job-lifecycle:
       executor: terraform/default

--- a/src/examples/deploy_using_remote_backend.yml
+++ b/src/examples/deploy_using_remote_backend.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    terraform: circleci/terraform@3.1
+    terraform: circleci/terraform@3.3
   jobs:
     single-job-lifecycle:
       executor: terraform/default

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -7,9 +7,9 @@ resource_class: << parameters.resource_class >>
 
 parameters:
   tag:
-    description: "Specify the Terraform Docker image tag for the executor"
+    description: "Specify the Terraform Docker image tag for the executor. Default to latest."
     type: "string"
-    default: "1.0.0" # update commands/install when updating this
+    default: "latest" # update commands/install when updating this
 
   resource_class:
     description: "Specify the resource class for Docker Executor"


### PR DESCRIPTION
I'm updating the default executor to be latest, and the install command to install latest by default as well. This will avoid common issues when people don't specify anything and uses the old version 1.0.0 which is not compatible with some things today.