### PR TITLE
Support absolute path for backend and var file

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -53,7 +53,9 @@ workflows:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       # Run any integration tests defined within the `jobs` key.
-      - test-absolute-path
+      - test-absolute-path:
+          context: CPE_ORBS_AWS
+          filters: *filters
       - validate-command-sequence:
           context: CPE_ORBS_AWS
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -7,6 +7,17 @@ filters: &filters
     only: /.*/
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  test-absolute-path:
+    executor: terraform/default
+    steps:
+      - checkout
+      - terraform/init:
+          path: "src/infra"
+      - run: |
+          echo 'purpose = "To test absolute path"' > $HOME/a.tfvar
+      - terraform/plan:
+          var_file: $HOME/a.tfvar
+          path: "src/infra"
   validate-command-sequence:
     executor: terraform/default
     steps:
@@ -42,6 +53,7 @@ workflows:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       # Run any integration tests defined within the `jobs` key.
+      - test-absolute-path
       - validate-command-sequence:
           context: CPE_ORBS_AWS
           filters: *filters
@@ -109,6 +121,7 @@ workflows:
             - terraform/plan
             - terraform/apply
             - terraform/destroy
+            - test-absolute-path
           context: orb-publisher
           github-token: GHI_TOKEN
           filters:

--- a/src/scripts/apply.sh
+++ b/src/scripts/apply.sh
@@ -19,7 +19,7 @@ fi
 # the following is needed to process backend configs
 if [[ -n "${TF_PARAM_BACKEND_CONFIG_FILE}" ]]; then
     for file in $(echo "${TF_PARAM_BACKEND_CONFIG_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             INIT_ARGS="$INIT_ARGS -backend-config=$file"
         else
             echo "Backend config '$file' wasn't found" >&2
@@ -44,7 +44,7 @@ if [[ -n "${TF_PARAM_VAR}" ]]; then
 fi
 if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
     for file in $(eval echo "${TF_PARAM_VAR_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             PLAN_ARGS="$PLAN_ARGS -var-file=$file"
         else
             echo "var file '$file' wasn't found" >&2

--- a/src/scripts/destroy.sh
+++ b/src/scripts/destroy.sh
@@ -22,7 +22,7 @@ fi
 # Initialize terraform
 if [[ -n "${TF_PARAM_BACKEND_CONFIG_FILE}" ]]; then
     for file in $(echo "${TF_PARAM_BACKEND_CONFIG_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             INIT_ARGS="$INIT_ARGS -backend-config=$file"
         else
             echo "Backend config '$file' wasn't found" >&2
@@ -70,7 +70,7 @@ fi
 
 if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
     for file in $(eval echo "${TF_PARAM_VAR_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             PLAN_ARGS="$PLAN_ARGS -var-file=$file"
         else
             echo "Var file '$file' wasn't found" >&2

--- a/src/scripts/init.sh
+++ b/src/scripts/init.sh
@@ -22,7 +22,7 @@ fi
 # Initialize terraform
 if [[ -n "${TF_PARAM_BACKEND_CONFIG_FILE}" ]]; then
     for file in $(echo "${TF_PARAM_BACKEND_CONFIG_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             INIT_ARGS="$INIT_ARGS -backend-config=$file"
         else
             echo "Backend config '$file' wasn't found" >&2

--- a/src/scripts/plan.sh
+++ b/src/scripts/plan.sh
@@ -18,7 +18,7 @@ fi
 # the following is needed to process backend configs
 if [[ -n "${TF_PARAM_BACKEND_CONFIG_FILE}" ]]; then
     for file in $(echo "${TF_PARAM_BACKEND_CONFIG_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             INIT_ARGS="$INIT_ARGS -backend-config=$file"
         else
             echo "Backend config '$file' wasn't found" >&2
@@ -56,7 +56,7 @@ if [[ -n "${TF_PARAM_VAR}" ]]; then
 fi
 if [[ -n "${TF_PARAM_VAR_FILE}" ]]; then
     for file in $(eval echo "${TF_PARAM_VAR_FILE}" | tr ',' '\n'); do
-        if [[ -f "$module_path/$file" ]]; then
+        if [[ -f "$module_path/$file" ]] || [[ -f "$file" ]]; then
             PLAN_ARGS="$PLAN_ARGS -var-file=$file"
         else
             echo "var file '$file' wasn't found" >&2


### PR DESCRIPTION
Resolves #98 
The version 3 of the orb stopped validating location of these files on the absolute path and only validates local path. I'm adding the validation for absolute path again.
I'm adding a test to verify absolute path is working.