### PR TITLE
Re add init to destroy job

### DIFF
--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -33,7 +33,7 @@ parameters:
     default: ""
   out:
     type: string
-    description: The file path to save your terraform plan to.
+    description: The file path to save your terraform plan to. Set this to "" if you are using terraform cloud.
     default: "plan.out"
   timeout:
     description: Configure a custom timeout limit

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -71,8 +71,12 @@ steps:
       steps:
         - attach_workspace:
             at: << parameters.workspace-root >>
-  #- init:
-  #    path: << parameters.path >>
+  - init:
+      path: << parameters.path >>
+      backend_config: << parameters.backend_config >>
+      backend_config_file: << parameters.backend_config_file >>
+      cli_config_file: << parameters.cli_config_file >>
+      timeout: <<parameters.timeout>>
   - destroy:
       path: << parameters.path >>
       var: << parameters.var >>

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -57,7 +57,7 @@ parameters:
     default: "1.0.0" # update commands/install when updating this
   out:
     type: string
-    description: The file path to save your terraform plan to.
+    description: The file path to save your terraform plan to. Set this to "" if you are using terraform cloud.
     default: "plan.out"
   timeout:
     description: "Configure a custom timeout limit"


### PR DESCRIPTION
Resolves #85 
In PR #6 the init was removed from this job and added to the destroy script directly. This was later removed from the script and the job stopped having a init command, I'm adding it again following the standard used on apply and plan commands.

I'm also adding some extra description in the param out for plan job and command, to make clarity about Terraform cloud.