### PR TITLE
Add AWS PRM default tags for partner revenue measurement

### DIFF
--- a/src/infra/main.tf
+++ b/src/infra/main.tf
@@ -1,5 +1,12 @@
 provider "aws" {
   region = "us-west-1"
+  default_tags {
+    tags = {
+    aws-apn-id = "pc:prod-npbeysvqzcwba"
+    # Environment = var.environment
+    # ManagedBy   = "CircleCI"
+    }
+  }
 }
 
 terraform {


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, Related Issues

Adding AWS Partner Revenue Measurement (PRM) tagging via default_tags on the
AWS provider. This ensures all resources created by the orb's test
infrastructure are tagged with our APN partner ID (prod-npbeysvqzcwba) for
revenue attribution.

Reference: https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/what-is-service.html

### Description

Add a default_tags block to the AWS provider in src/infra/main.tf with
the aws-apn-id tag. This automatically applies the tag to all AWS resources
without modifying individual resource blocks.